### PR TITLE
Prevent multiple job runs.

### DIFF
--- a/assets/components/cronmanager/cron.php
+++ b/assets/components/cronmanager/cron.php
@@ -15,10 +15,22 @@ $rundatetime = date('Y-m-d H:i:s');
 
 // get all cronjobs wich needs to be runned
 $cronjobs = $modx->getCollection('modCronjob', array(
-	'nextrun' => null,
-	'OR:nextrun:<=' => $rundatetime,
-	'active' => true,
+	array(
+		'nextrun' => null,
+		'OR:nextrun:<=' => $rundatetime
+	),
+	'active' => true
 ));
+
+/** 
+ *@var modCronjob $cronjob 
+ * Set the next run times for the cronjobs
+ */
+foreach($cronjobs as $cronjob) {
+	$cronjob->set('nextrun', date('Y-m-d H:i:s', (strtotime($rundatetime)+($cronjob->get('minutes')*60))));
+	$cronjob->save();
+}
+
 /** @var modCronjob $cronjob */
 foreach($cronjobs as $cronjob) {
 
@@ -80,7 +92,7 @@ foreach($cronjobs as $cronjob) {
 	$logs[] = $log;
 	
 	$cronjob->set('lastrun', $rundatetime);
-	$cronjob->set('nextrun', date('Y-m-d H:i:s', (strtotime($rundatetime)+($cronjob->get('minutes')*60))));
+	//$cronjob->set('nextrun', date('Y-m-d H:i:s', (strtotime($rundatetime)+($cronjob->get('minutes')*60))));
 	$cronjob->addMany($logs);
 	$cronjob->save();
 }


### PR DESCRIPTION
I have modified the query and added a foreach loop to update the nextrun time. This way, if a the cron is set to run every five minutes, and there are snippets set to run once a day, but it takes longer than 5 minutes to run those jobs, they wont run more than once in that day.
