### PR TITLE
Various improvements to execution order

### DIFF
--- a/assets/components/cronmanager/cron.php
+++ b/assets/components/cronmanager/cron.php
@@ -73,7 +73,7 @@ while($cronjob = $modx->getObject('modCronjob', $c)) {
         $properties = array();
     }
     $properties['CronManager'] = '1';
-    $properties['cronjob'] = $cronjob;
+    $properties['CronManagerJob'] = $cronjob;
 
     if ($cronmanager->getOption('debug')) {
         $modx->log(modX::LOG_LEVEL_ERROR, 'CronManager Job: ' . $cronjob->get('title') . ' (' . $cronjob->get('id') . ') properties: ' . print_r($properties, true), '', 'CronManager');


### PR DESCRIPTION
Order of execution is determined by **nextrun** property, so the earliest date always means earliest execution.

Instead of fetching all cron jobs at once, keep getting them one by one, to make sure their current status allows execution.
If the user changes **nextrun** or **active**, while other jobs are running, his changes will take effect immediately.
This will also partially prevent duplicate cron job instances from running, if it completes successfully before **nextrun + minues**.

Pass the entire **modCronjob** instance as snippet parameter, so snippet can determine, which job triggered it, and make changes to **active** property (for example, disable cron job, if something wrong happened or to entirely block duplicate instances from running at the same time). This will also allow to add custom log data as well.

