### PR TITLE
Implement catch-up behavior for cron jobs

### DIFF
--- a/core/components/cronmanager/processors/web/cron/run.class.php
+++ b/core/components/cronmanager/processors/web/cron/run.class.php
@@ -69,10 +69,30 @@ class CronMananagerCronRunProcessor extends Processor
         }
         $c->sortby('nextrun');
 
+        // Get catch-up behavior option (default: enabled for backward compatibility)
+        // 1 = enable catch-up (original behavior)
+        // 0 = disable catch-up (reschedule from current time)
+        $catchup = (int)$this->cronmanager->getOption('cron_enable_catchup', null, 0);
+            
         /** @var modCronjob $cronjob */
         $cronjobs = $this->modx->getIterator('modCronjob', $c);
         foreach ($cronjobs as $cronjob) {
+            // Determine initial base datetime for scheduling
             $rundatetime = ($cronjob->get('nextrun')) ? $cronjob->get('nextrun') : date('Y-m-d H:i:s');
+           
+            if (!$catchup) {
+                // Catch-up disabled:
+                // Always reschedule based on the current time to avoid executing missed runs
+                $rundatetime = date('Y-m-d H:i:s');
+            } else {
+                // Catch-up enabled:
+                // If nextrun is significantly in the past, reset to current time
+                // This prevents excessive back-to-back executions ("catch-up loops")
+                if (strtotime($rundatetime) < time() - 60) {
+                    $rundatetime = date('Y-m-d H:i:s');
+                }
+            }
+
             $properties = $cronjob->get('properties');
             if (!empty($properties)) {
                 /** @var modPropertySet $propset */
@@ -140,9 +160,9 @@ class CronMananagerCronRunProcessor extends Processor
             $logs = [$log];
 
             $cronjob->set('lastrun', $rundatetime);
-            if ($this->cronmanager->getOption('daylight_saving') && $cronjob->get('minutes') > 60) {
+            if ($this->cronmanager->getOption('daylight_saving') && $cronjob->get('minutes') > 60) {    
                 $cronjob->set('nextrun', date('Y-m-d H:i:s', strtotime($cronjob->get('minutes') . ' minutes', (strtotime($rundatetime)))));
-            } else {
+            } else {    
                 $cronjob->set('nextrun', date('Y-m-d H:i:s', (strtotime($rundatetime) + ($cronjob->get('minutes') * 60))));
             }
             $cronjob->set('running', false);


### PR DESCRIPTION
**Why it is needed**

When there is a server downtime or when the system cron (calling cron.php) is stopped for any reason, scheduled jobs may accumulate delay.

In the current implementation, the next run (`nextrun`) is always calculated based on the previous `nextrun` value. If this value is already in the past, the new `nextrun` can also remain in the past.

This can lead to repeated immediate executions ("catch-up loops") until the scheduler catches up with the current time. In some cases, this may cause unnecessary load or unexpected behavior, especially for jobs that are not designed to run multiple times in quick succession.

This change introduces an option to control this behavior:
- either keep the existing catch-up mechanism,
- or reschedule jobs from the current time, avoiding execution of missed runs.

This provides safer and more predictable behavior for most use cases while preserving backward compatibility.

**What this PR does**

Add a cron_catchup system option to control how missed executions are handled.

When disabled, cronjobs are always rescheduled from the current time, avoiding catch-up loops after downtime.

When enabled, the existing behavior is preserved, with a safeguard against outdated nextrun values to prevent infinite execution loops.

